### PR TITLE
add Vitest unit tests and CI workflow for the frontend

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-# Запускает Vitest при push и в PR в основные ветки репозитория.
+# Run Vitest on push and on pull requests into main, dev, or UAT.
 name: Unit tests
 
 on:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,25 @@
+# Запускает Vitest при push и в PR в основные ветки репозитория.
+name: Unit tests
+
+on:
+  push:
+    branches: [main, dev, UAT]
+  pull_request:
+    branches: [main, dev, UAT]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^22.16.5",
@@ -107,6 +108,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3464,6 +3490,43 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3521,6 +3584,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -5055,6 +5125,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6908,6 +6988,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7552,6 +7642,51 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.16.5",

--- a/src/components/LocationPickerMap.coords.test.ts
+++ b/src/components/LocationPickerMap.coords.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { hasValidEventCoordinates } from './LocationPickerMap';
+
+describe('hasValidEventCoordinates', () => {
+  it('rejects null, NaN, and 0,0 placeholder', () => {
+    expect(hasValidEventCoordinates(null, 1)).toBe(false);
+    expect(hasValidEventCoordinates(1, null)).toBe(false);
+    expect(hasValidEventCoordinates(NaN, 1)).toBe(false);
+    expect(hasValidEventCoordinates(0, 0)).toBe(false);
+  });
+
+  it('accepts finite non-zero coordinates', () => {
+    expect(hasValidEventCoordinates(40.7128, -74.006)).toBe(true);
+    expect(hasValidEventCoordinates(-0.001, 12.3)).toBe(true);
+  });
+});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getApiUrl, API_BASE_URL } from './api';
+
+describe('getApiUrl', () => {
+  it('prepends slash when path omits it', () => {
+    expect(getApiUrl('api/events')).toBe(`${API_BASE_URL}/api/events`);
+  });
+
+  it('does not duplicate slash when path starts with /', () => {
+    expect(getApiUrl('/api/events')).toBe(`${API_BASE_URL}/api/events`);
+  });
+});

--- a/src/lib/apiClient.test.ts
+++ b/src/lib/apiClient.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiClient } from './apiClient';
+
+function jsonResponse(body: unknown, init: ResponseInit & { json?: boolean } = {}) {
+  const headers = new Headers(init.headers);
+  if (init.json !== false) headers.set('content-type', 'application/json');
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+describe('apiClient', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('get returns parsed JSON on 200', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ hello: 'world' }));
+    await expect(apiClient.get<{ hello: string }>('/api/x')).resolves.toEqual({ hello: 'world' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/x');
+    expect(init?.method ?? 'GET').toBe('GET');
+  });
+
+  it('post sends JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiClient.post('/api/y', { a: 1 });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(init?.body).toBe(JSON.stringify({ a: 1 }));
+  });
+
+  it('throws ApiError with detail from JSON error body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ detail: 'Not found' }, { status: 404, statusText: 'Not Found' }),
+    );
+    await expect(apiClient.get('/missing')).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'Not found',
+      status: 404,
+    });
+  });
+
+  it('throws ApiError with text body when not JSON', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('plain error', { status: 502, headers: { 'content-type': 'text/plain' } }),
+    );
+    await expect(apiClient.get('/bad')).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'plain error',
+      status: 502,
+    });
+  });
+});

--- a/src/lib/authProfile.test.ts
+++ b/src/lib/authProfile.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchAuthUserFromToken, sameAuthUserId } from './authProfile';
+
+describe('sameAuthUserId', () => {
+  it('returns false for missing values', () => {
+    expect(sameAuthUserId('', 'a')).toBe(false);
+    expect(sameAuthUserId('a', undefined)).toBe(false);
+  });
+
+  it('compares case-insensitively with trim', () => {
+    expect(sameAuthUserId('  Abc-123  ', 'abc-123')).toBe(true);
+    expect(sameAuthUserId('x', 'y')).toBe(false);
+  });
+});
+
+describe('fetchAuthUserFromToken', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null when response is not ok', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 401 }));
+    await expect(fetchAuthUserFromToken('tok')).resolves.toBeNull();
+  });
+
+  it('returns null when id is missing or not a string', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ email: 'a@b.com' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await expect(fetchAuthUserFromToken('tok')).resolves.toBeNull();
+  });
+
+  it('returns trimmed id and email on success', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '  uuid-1  ', email: 'e@x.com' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await expect(fetchAuthUserFromToken(' bearer ')).resolves.toEqual({
+      id: 'uuid-1',
+      email: 'e@x.com',
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).toMatchObject({ Authorization: 'Bearer bearer' });
+  });
+});

--- a/src/lib/documentTitle.test.ts
+++ b/src/lib/documentTitle.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { APP_NAME, DEFAULT_DOCUMENT_TITLE, formatPageTitle } from './documentTitle';
+
+describe('formatPageTitle', () => {
+  it('returns default title for empty or whitespace', () => {
+    expect(formatPageTitle('')).toBe(DEFAULT_DOCUMENT_TITLE);
+    expect(formatPageTitle('   ')).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+
+  it('formats non-empty page title with app suffix', () => {
+    expect(formatPageTitle('Home')).toBe(`Home · ${APP_NAME}`);
+    expect(formatPageTitle('  Events  ')).toBe(`Events · ${APP_NAME}`);
+  });
+});

--- a/src/lib/eventTime.test.ts
+++ b/src/lib/eventTime.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { EventItem } from '@/lib/storage';
+import { eventStartMs, isEventUpcoming } from './eventTime';
+
+const baseEvent = (over: Partial<EventItem>): EventItem =>
+  ({
+    id: '1',
+    title: 'T',
+    description: 'D',
+    category: 'Music',
+    date: '2030-06-15',
+    time: '18:00',
+    location: 'L',
+    lat: 1,
+    lng: 2,
+    budget: 0,
+    participantsLimit: 10,
+    participants: [],
+    image: '',
+    organizer: 'o',
+    organizerId: 'oid',
+    organizerAvatar: '',
+    isPrivate: false,
+    isDraft: false,
+    requiresApproval: false,
+    reviews: [],
+    reports: [],
+    collaborators: [],
+    ...over,
+  }) as EventItem;
+
+describe('eventStartMs', () => {
+  it('parses date and time to epoch ms', () => {
+    const ms = eventStartMs(baseEvent({ date: '2030-01-02', time: '12:30' }));
+    expect(Number.isFinite(ms)).toBe(true);
+    expect(new Date(ms).toISOString().startsWith('2030-01-02')).toBe(true);
+  });
+
+  it('defaults time to midnight when empty', () => {
+    const ms = eventStartMs(baseEvent({ date: '2030-03-04', time: '' }));
+    expect(Number.isFinite(ms)).toBe(true);
+  });
+});
+
+describe('isEventUpcoming', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-06-01T12:00:00'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true when start is after “now”', () => {
+    expect(isEventUpcoming(baseEvent({ date: '2030-12-01', time: '10:00' }))).toBe(true);
+  });
+
+  it('returns false when start is in the past', () => {
+    expect(isEventUpcoming(baseEvent({ date: '2020-01-01', time: '10:00' }))).toBe(false);
+  });
+
+  it('returns false for invalid date', () => {
+    expect(isEventUpcoming(baseEvent({ date: 'not-a-date', time: '10:00' }))).toBe(false);
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './utils';
+
+describe('cn', () => {
+  it('merges class names and resolves tailwind conflicts', () => {
+    expect(cn('px-2 py-1', 'px-4')).toBe('py-1 px-4');
+  });
+
+  it('filters falsy entries', () => {
+    expect(cn('a', false, 'b', undefined)).toBe('a b');
+  });
+});

--- a/src/pages/ChatPage.test.tsx
+++ b/src/pages/ChatPage.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { User } from '@/lib/storage';
+import ChatPage from './ChatPage';
+
+const { getCurrentUserMock } = vi.hoisted(() => ({
+  getCurrentUserMock: vi.fn<[], User | null>(),
+}));
+
+vi.mock('@/lib/storage', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/lib/storage')>();
+  return {
+    ...mod,
+    getCurrentUser: () => getCurrentUserMock(),
+  };
+});
+
+vi.mock('@/components/BottomNav', () => ({
+  default: () => null,
+}));
+
+const chatUser = {
+  id: 'u-chat',
+  name: 'Chatter',
+  email: 'c@test.com',
+  role: 'participant' as const,
+  password: 'secret123',
+  avatar: '',
+  profilePhoto: '',
+  coverPhoto: '',
+  bio: '',
+  interests: [],
+  dob: '',
+  gender: '',
+  isPremium: false,
+  friends: [],
+  createdAt: '',
+} satisfies User;
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockReturnValue(chatUser);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 500 }))),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderChat() {
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} initialEntries={['/chat']}>
+        <Routes>
+          <Route path="/chat" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('unlocks chat with password and sends a message', async () => {
+    renderChat();
+
+    expect(screen.getByText(/Chat Protected/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Password/i }));
+
+    const pw = screen.getByPlaceholderText(/Enter your password/i);
+    fireEvent.change(pw, { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /Unlock Chat/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Chats')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /DJ Luna/i }));
+
+    const input = screen.getByPlaceholderText(/Type a message/i);
+    fireEvent.change(input, { target: { value: 'Hello from test' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello from test')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when unlock password is wrong', async () => {
+    renderChat();
+    fireEvent.click(screen.getByRole('button', { name: /Password/i }));
+    fireEvent.change(screen.getByPlaceholderText(/Enter your password/i), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /Unlock Chat/i }));
+
+    expect(await screen.findByText(/Incorrect password/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/CreateEventPage.test.tsx
+++ b/src/pages/CreateEventPage.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { User } from '@/lib/storage';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CreateEventPage from './CreateEventPage';
+
+const { addEventMock, mockNavigate } = vi.hoisted(() => ({
+  addEventMock: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/components/BottomNav', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/LocationPickerMap', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/LocationPickerMap')>();
+  return {
+    ...actual,
+    default: function MockLocationPicker({
+      onLocationChange,
+    }: {
+      onLocationChange: (lat: number, lng: number) => void;
+    }) {
+      return (
+        <button type="button" onClick={() => onLocationChange(40.7128, -74.006)}>
+          set-map-pin
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock('@/lib/auth', () => ({
+  getAuthToken: () => 'test-token',
+  setAuthToken: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+  },
+}));
+
+vi.mock('@/lib/storage', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/lib/storage')>();
+  const minimalUser = {
+    id: 'u1',
+    name: 'Organizer',
+    email: 'o@example.com',
+    role: 'organizer' as const,
+    password: '',
+    avatar: '',
+    profilePhoto: '',
+    coverPhoto: '',
+    bio: '',
+    interests: [],
+    dob: '',
+    gender: '',
+    isPremium: false,
+    friends: [],
+    createdAt: '',
+  } satisfies User;
+  return {
+    ...mod,
+    getCurrentUser: () => minimalUser,
+    addEvent: addEventMock,
+  };
+});
+
+function tomorrowIsoDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+describe('CreateEventPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    addEventMock.mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 500 }))),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderPage() {
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        initialEntries={['/create']}
+      >
+        <Routes>
+          <Route path="/create" element={<CreateEventPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('shows validation errors when publishing without required fields', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /publish event/i }));
+    expect(await screen.findByText('Title is required')).toBeInTheDocument();
+    expect(screen.getByText('Click the map to set the event location')).toBeInTheDocument();
+    expect(addEventMock).not.toHaveBeenCalled();
+  });
+
+  it('calls addEvent and navigates home after successful publish', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/api/events') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 'evt-1', created_by: 'u1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('not mocked', { status: 500 });
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Event Title'), { target: { value: 'Meetup' } });
+    fireEvent.change(screen.getByPlaceholderText('Description'), { target: { value: 'Details here' } });
+    const dates = document.querySelectorAll('input[type="date"]');
+    const times = document.querySelectorAll('input[type="time"]');
+    fireEvent.change(dates[0], { target: { value: tomorrowIsoDate() } });
+    fireEvent.change(times[0], { target: { value: '15:00' } });
+    fireEvent.change(screen.getByPlaceholderText(/central park/i), { target: { value: 'Central Park' } });
+    fireEvent.click(screen.getByRole('button', { name: /set-map-pin/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /publish event/i }));
+
+    await waitFor(() => {
+      expect(addEventMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText('Event Published Successfully!')).toBeInTheDocument();
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/home');
+      },
+      { timeout: 3000 },
+    );
+  });
+});

--- a/src/pages/CreateEventPage.tsx
+++ b/src/pages/CreateEventPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, ShieldCheck } from 'lucide-react';
 import { addEvent, getCurrentUser, type EventItem } from '@/lib/storage';
@@ -171,8 +171,8 @@ export default function CreateEventPage() {
 
       const responseData = await res.json();
       const { id: apiEventId, created_by: apiCreatedBy } = extractCreatedEventPayload(responseData);
-      const { data: authUserData } = await supabase.auth.getUser();
-      const authUser = authUserData?.user;
+      const authUser =
+        supabase == null ? undefined : (await supabase.auth.getUser()).data?.user ?? undefined;
 
       const organizerId = apiCreatedBy || user?.id || authUser?.id || 'current_user';
       const organizerName =

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { EventItem, User } from '@/lib/storage';
+import HomePage from './HomePage';
+
+const { getCurrentUserMock, getUsersMock, getEventsMock } = vi.hoisted(() => ({
+  getCurrentUserMock: vi.fn<[], User | null>(),
+  getUsersMock: vi.fn<[], User[]>(),
+  /** HomePage imports `getEvents as getLocalEvents` — must mock `getEvents`. */
+  getEventsMock: vi.fn<[], EventItem[]>(),
+}));
+
+vi.mock('@/lib/storage', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/lib/storage')>();
+  return {
+    ...mod,
+    getCurrentUser: () => getCurrentUserMock(),
+    getUsers: () => getUsersMock(),
+    getEvents: () => getEventsMock(),
+  };
+});
+
+vi.mock('@/components/BottomNav', () => ({
+  default: () => null,
+}));
+
+function makeUser(over: Partial<User> & Pick<User, 'id'>): User {
+  return {
+    name: 'User',
+    email: 'u@u.com',
+    role: 'participant',
+    password: '',
+    avatar: '',
+    profilePhoto: '',
+    coverPhoto: '',
+    bio: '',
+    interests: ['Music'],
+    dob: '',
+    gender: '',
+    isPremium: false,
+    friends: [],
+    createdAt: '',
+    ...over,
+  } as User;
+}
+
+const uMe = makeUser({ id: 'u-me', name: 'Me', email: 'me@test.com' });
+const uOther = makeUser({ id: 'u-other', name: 'Alice', email: 'alice@test.com' });
+
+const apiEventRow = {
+  id: 'api-e1',
+  title: 'Backend Event Alpha',
+  description: 'desc',
+  category: 'Music',
+  start_datetime: '2030-07-20T15:00:00.000Z',
+  cost: 25,
+  max_capacity: 50,
+  location_name: 'Berlin',
+  latitude: 52.5,
+  longitude: 13.4,
+  created_by: 'creator-1',
+};
+
+function localEvent(over: Partial<EventItem> & Pick<EventItem, 'id' | 'title'>): EventItem {
+  return {
+    description: '',
+    category: 'Music',
+    date: '2030-08-01',
+    time: '12:00',
+    location: 'Berlin',
+    lat: 52,
+    lng: 13,
+    budget: 10,
+    participantsLimit: 50,
+    participants: [],
+    image: 'https://example.com/i.jpg',
+    organizer: 'Org',
+    organizerId: 'o1',
+    organizerAvatar: '',
+    isPrivate: false,
+    isDraft: false,
+    requiresApproval: false,
+    reviews: [],
+    reports: [],
+    collaborators: [],
+    ...over,
+  } as EventItem;
+}
+
+function jsonOk(data: unknown) {
+  return new Response(JSON.stringify(data), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+describe('HomePage', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+
+  beforeEach(() => {
+    getCurrentUserMock.mockReturnValue(uMe);
+    getUsersMock.mockReturnValue([uMe]);
+    getEventsMock.mockReturnValue([]);
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderHome() {
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<HomePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('shows loading then renders events from API response', async () => {
+    let resolveEvents: (r: Response) => void;
+    const eventsPromise = new Promise<Response>((res) => {
+      resolveEvents = res;
+    });
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('max-price')) return Promise.resolve(jsonOk({ max_price: 500 }));
+      if (url.includes('/api/events')) return eventsPromise;
+      return Promise.reject(new Error('unmocked'));
+    });
+
+    renderHome();
+    expect(screen.getByText(/Loading the latest events/i)).toBeInTheDocument();
+    resolveEvents!(jsonOk({ data: [apiEventRow] }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Backend Event Alpha')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Loading the latest events/i)).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when API returns no events and local storage is empty', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('max-price')) return Promise.resolve(jsonOk({ max_price: 500 }));
+      if (url.includes('/api/events')) return Promise.resolve(jsonOk({ data: [] }));
+      return Promise.reject(new Error('unmocked'));
+    });
+
+    renderHome();
+    await waitFor(() => {
+      expect(screen.getByText(/No events match your current filters/i)).toBeInTheDocument();
+    });
+  });
+
+  it('merges local events when API returns an empty list', async () => {
+    const local = localEvent({ id: 'loc-1', title: 'Local Only Event', budget: 5 });
+    getEventsMock.mockReturnValue([local]);
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('max-price')) return Promise.resolve(jsonOk({ max_price: 500 }));
+      if (url.includes('/api/events')) return Promise.resolve(jsonOk({ data: [] }));
+      return Promise.reject(new Error('unmocked'));
+    });
+
+    renderHome();
+    await waitFor(() => {
+      expect(screen.getByText('Local Only Event')).toBeInTheDocument();
+    });
+  });
+
+  it('requests filtered events when category chip is selected', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('max-price')) return Promise.resolve(jsonOk({ max_price: 500 }));
+      if (url.includes('/api/events')) return Promise.resolve(jsonOk({ data: [apiEventRow] }));
+      return Promise.reject(new Error('unmocked'));
+    });
+
+    renderHome();
+    await waitFor(() => expect(screen.getByText('Backend Event Alpha')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sports' }));
+
+    await waitFor(() => {
+      const withCategory = fetchMock.mock.calls
+        .map((c) => String(c[0]))
+        .filter((u) => u.includes('category=Sports'));
+      expect(withCategory.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders recommendation-style “People You May Match” when other users exist', async () => {
+    getUsersMock.mockReturnValue([uMe, uOther]);
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('max-price')) return Promise.resolve(jsonOk({ max_price: 500 }));
+      if (url.includes('/api/events')) return Promise.resolve(jsonOk({ data: [apiEventRow] }));
+      return Promise.reject(new Error('unmocked'));
+    });
+
+    renderHome();
+    await waitFor(() => expect(screen.getByText('Backend Event Alpha')).toBeInTheDocument());
+
+    expect(screen.getByText('People You May Match')).toBeInTheDocument();
+    expect(screen.getByText('AI')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+});

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import LoginPage from './LoginPage';
+import { clearAuthToken } from '@/lib/auth';
+
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: null,
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    clearAuthToken();
+    sessionStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 500 }))),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderPage() {
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        initialEntries={['/login']}
+      >
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('shows validation errors when fields are empty', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(await screen.findByText('Email required')).toBeInTheDocument();
+    expect(screen.getByText('Password required')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows invalid credentials when login returns non-OK', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: 'bad' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText('Invalid credentials')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to home after successful login', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/api/auth/login')) {
+        return new Response(
+          JSON.stringify({
+            access_token: 'at1',
+            refresh_token: 'rt1',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/auth/me')) {
+        return new Response(JSON.stringify({ id: 'user-99', email: 'a@b.com' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('not mocked', { status: 500 });
+    });
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+  });
+});

--- a/src/pages/SignupPage.test.tsx
+++ b/src/pages/SignupPage.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SignupPage from './SignupPage';
+import { clearAuthToken } from '@/lib/auth';
+
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: null,
+}));
+
+describe('SignupPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    clearAuthToken();
+    sessionStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 500 }))),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderPage() {
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        initialEntries={['/signup']}
+      >
+        <Routes>
+          <Route path="/signup" element={<SignupPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('shows validation messages when submitting empty form', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText('Email is required')).toBeInTheDocument();
+    expect(screen.getByText('Password is required')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows conflict message when server returns 409', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'User exists' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'Alex' } });
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'alex@example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: 'secret1' } });
+    const dobInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dobInput, { target: { value: '2000-01-15' } });
+    const genderSelect = screen.getByRole('combobox');
+    fireEvent.change(genderSelect, { target: { value: 'Male' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^create account$/i }));
+
+    expect(await screen.findByText('An account with this email already exists.')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('registers and navigates home when API returns tokens and profile loads', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/api/auth/register')) {
+        return new Response(
+          JSON.stringify({ access_token: 'tok', refresh_token: 'ref' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/auth/me')) {
+        return new Response(JSON.stringify({ id: 'new-user', email: 'alex@example.com' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('not mocked', { status: 500 });
+    });
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Full Name'), { target: { value: 'Alex' } });
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'alex@example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: 'secret1' } });
+    const dobInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dobInput, { target: { value: '2000-01-15' } });
+    const genderSelect = screen.getByRole('combobox');
+    fireEvent.change(genderSelect, { target: { value: 'Female' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^create account$/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+  });
+});

--- a/src/test/example.test.ts
+++ b/src/test/example.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("example", () => {
-  it("should pass", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,32 @@
 import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+import { clearAuthToken } from "@/lib/auth";
+import {
+  logout,
+  saveEvents,
+  saveJoinRequests,
+  saveNotifications,
+  saveTickets,
+  saveUsers,
+} from "@/lib/storage";
+
+afterEach(() => {
+  cleanup();
+  clearAuthToken();
+  logout();
+  saveUsers([]);
+  saveEvents([]);
+  saveJoinRequests([]);
+  saveTickets([]);
+  saveNotifications([]);
+  try {
+    sessionStorage.clear();
+  } catch {
+    /* ignore */
+  }
+  vi.clearAllMocks();
+});
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
- Vitest/RTL tests for auth flows, home/chat/create event, and lib helpers
- CI workflow on push/PR to main, dev, UAT
- Test setup cleanup; optional @testing-library/dom
- Fix CreateEventPage when Supabase client is unavailable

Closes #90