### PR TITLE
Move unit tests into a separate folder

### DIFF
--- a/src/__tests__/components/LocationPickerMap.coords.test.ts
+++ b/src/__tests__/components/LocationPickerMap.coords.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hasValidEventCoordinates } from './LocationPickerMap';
+import { hasValidEventCoordinates } from '@/components/LocationPickerMap';
 
 describe('hasValidEventCoordinates', () => {
   it('rejects null, NaN, and 0,0 placeholder', () => {

--- a/src/__tests__/lib/api.test.ts
+++ b/src/__tests__/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getApiUrl, API_BASE_URL } from './api';
+import { getApiUrl, API_BASE_URL } from '@/lib/api';
 
 describe('getApiUrl', () => {
   it('prepends slash when path omits it', () => {

--- a/src/__tests__/lib/apiClient.test.ts
+++ b/src/__tests__/lib/apiClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiClient } from './apiClient';
+import { apiClient } from '@/lib/apiClient';
 
 function jsonResponse(body: unknown, init: ResponseInit & { json?: boolean } = {}) {
   const headers = new Headers(init.headers);

--- a/src/__tests__/lib/authProfile.test.ts
+++ b/src/__tests__/lib/authProfile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchAuthUserFromToken, sameAuthUserId } from './authProfile';
+import { fetchAuthUserFromToken, sameAuthUserId } from '@/lib/authProfile';
 
 describe('sameAuthUserId', () => {
   it('returns false for missing values', () => {

--- a/src/__tests__/lib/documentTitle.test.ts
+++ b/src/__tests__/lib/documentTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { APP_NAME, DEFAULT_DOCUMENT_TITLE, formatPageTitle } from './documentTitle';
+import { APP_NAME, DEFAULT_DOCUMENT_TITLE, formatPageTitle } from '@/lib/documentTitle';
 
 describe('formatPageTitle', () => {
   it('returns default title for empty or whitespace', () => {

--- a/src/__tests__/lib/eventTime.test.ts
+++ b/src/__tests__/lib/eventTime.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { EventItem } from '@/lib/storage';
-import { eventStartMs, isEventUpcoming } from './eventTime';
+import { eventStartMs, isEventUpcoming } from '@/lib/eventTime';
 
 const baseEvent = (over: Partial<EventItem>): EventItem =>
   ({

--- a/src/__tests__/lib/utils.test.ts
+++ b/src/__tests__/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cn } from './utils';
+import { cn } from '@/lib/utils';
 
 describe('cn', () => {
   it('merges class names and resolves tailwind conflicts', () => {

--- a/src/__tests__/pages/ChatPage.test.tsx
+++ b/src/__tests__/pages/ChatPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { User } from '@/lib/storage';
-import ChatPage from './ChatPage';
+import ChatPage from '@/pages/ChatPage';
 
 const { getCurrentUserMock } = vi.hoisted(() => ({
   getCurrentUserMock: vi.fn<[], User | null>(),

--- a/src/__tests__/pages/CreateEventPage.test.tsx
+++ b/src/__tests__/pages/CreateEventPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { User } from '@/lib/storage';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import CreateEventPage from './CreateEventPage';
+import CreateEventPage from '@/pages/CreateEventPage';
 
 const { addEventMock, mockNavigate } = vi.hoisted(() => ({
   addEventMock: vi.fn(),

--- a/src/__tests__/pages/HomePage.test.tsx
+++ b/src/__tests__/pages/HomePage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { EventItem, User } from '@/lib/storage';
-import HomePage from './HomePage';
+import HomePage from '@/pages/HomePage';
 
 const { getCurrentUserMock, getUsersMock, getEventsMock } = vi.hoisted(() => ({
   getCurrentUserMock: vi.fn<[], User | null>(),

--- a/src/__tests__/pages/LoginPage.test.tsx
+++ b/src/__tests__/pages/LoginPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import LoginPage from './LoginPage';
+import LoginPage from '@/pages/LoginPage';
 import { clearAuthToken } from '@/lib/auth';
 
 const { mockNavigate } = vi.hoisted(() => ({

--- a/src/__tests__/pages/SignupPage.test.tsx
+++ b/src/__tests__/pages/SignupPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import SignupPage from './SignupPage';
+import SignupPage from '@/pages/SignupPage';
 import { clearAuthToken } from '@/lib/auth';
 
 const { mockNavigate } = vi.hoisted(() => ({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/__tests__/**/*.{test,spec}.{ts,tsx}"],
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
- Mirror pages, lib, and components; resolve modules via @/ aliases
- Point Vitest include at src/__tests__ only
